### PR TITLE
Need to install Git even before the first Chef run (for Berkshelf)

### DIFF
--- a/scripts/update-vm.sh
+++ b/scripts/update-vm.sh
@@ -34,6 +34,16 @@ check_chefdk() {
   fi
 }
 
+check_git() {
+  big_step "Checking Git..."
+  if [[ $(which git) ]]; then
+    echo "Git already installed"
+  else
+    step "Installing Git"
+    sudo apt-get install git -y
+  fi
+}
+
 symlink_self() {
   big_step "Symlinking 'update-vm'..."
   sudo ln -sf $SCRIPT_FILE /usr/local/bin/update-vm
@@ -90,6 +100,7 @@ if [[ "$1" == "--verify-only" ]]; then
   verify_vm
 else
   check_chefdk
+  check_git
   symlink_self
   [[ "$1" == "--pull" ]] && update_repo
   update_vm


### PR DESCRIPTION
This is a stupid chicken / egg problem.

We need to install Git even before the first Chef run -- otherwise we can not use `:git` source locations in the `Berksfile`, which is quite a hard limitation (=> means we can not use forks of community cookbooks) 

So we install it right after ChefDK, still before the Chef run is started...
