### PR TITLE
Make sure we cache the `Chef::Config['file_cache_path']`

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,5 +30,12 @@ Vagrant::configure("2") do |config|
 
     # Install ChefDK and trigger the Chef run from within the VM
     devbox_config.vm.provision "shell", privileged: false, inline: "/vagrant/scripts/update-vm.sh"
+
+    # Ensure we cache as much as possible
+    if Vagrant.has_plugin?("vagrant-cachier")
+      devbox_config.cache.enable :generic, {
+        "chef_file_cache" => { cache_dir: "/home/vagrant/.chef/local-mode-cache/cache" }
+      }
+    end
   end
 end


### PR DESCRIPTION
Usually vagrant-cachier would already take care of this, but since we have no chef provisioners defined in the `Vagrantfile` cachier does not kick in.

So we manually define the `file_cache_path` directory to be cached...
