### PR TITLE
Restructure the README for better comprehensibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# CHANGELOG
+
+## 0.1 (unreleased)
+
+The initial release of the developer VM, including:
+
+ * Git
+ * ChefDK
+ * VIM
+
+See the [README](README.md) for more details.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# Linux Developer VM Example
+# Linux Developer VM Example / Template
 
 [![Circle CI](https://circleci.com/gh/Zuehlke/linux-developer-vm/tree/master.svg?style=shield)](https://circleci.com/gh/Zuehlke/linux-developer-vm/tree/master)
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,12 +10,12 @@ Vagrant::configure("2") do |config|
   end
 
   # set the hostname
-  config.vm.hostname = "linux-devbox.local"
+  config.vm.hostname = "linux-developer-vm.local"
 
   # virtualbox customizations
   config.vm.provider :virtualbox do |vbox, override|
     vbox.customize ["modifyvm", :id,
-      "--name", "Example Linux Developer VM",
+      "--name", "Linux Developer VM",
       "--memory", 512,
       "--cpus", Etc.nprocessors
     ]

--- a/cookbooks/vm/README.md
+++ b/cookbooks/vm/README.md
@@ -1,5 +1,5 @@
 # Linux Developer VM Cookbook
 
-A cookbook for setting up an basic Linux developer VM
+A cookbook for setting up a basic Linux Developer VM
 
 See: https://github.com/Zuehlke/linux-developer-vm

--- a/cookbooks/vm/metadata.rb
+++ b/cookbooks/vm/metadata.rb
@@ -2,11 +2,11 @@ name 'vm'
 maintainer 'Your Name'
 maintainer_email 'your.name@example.com'
 license 'MIT'
-description 'Installs/Configures a sample Linux Developer VM'
+description 'Installs/Configures a Linux Developer VM'
 long_description IO.read(File.join(File.dirname(__FILE__), '../../README.md'))
 version '0.1.0'
-issues_url 'https://github.com/zuehlke/linux-developer-vm/issues'
-source_url 'https://github.com/zuehlke/linux-developer-vm'
+issues_url 'https://github.com/Zuehlke/linux-developer-vm/issues'
+source_url 'https://github.com/Zuehlke/linux-developer-vm'
 
 supports 'ubuntu'
 


### PR DESCRIPTION
This PR improves the structure of the README to better guide the user.

It now clearly separates between:

 * Usage - how to use the exported developer VM image
 * Development - how to develop / extend it via Vagrant

See also https://github.com/tknerr/linus-kitchen/pull/50