### PR TITLE
Remove rubocop

### DIFF
--- a/cookbooks/vm/.rubocop.yml
+++ b/cookbooks/vm/.rubocop.yml
@@ -1,9 +1,0 @@
-Metrics/LineLength:
-  Enabled: false
-
-Style/EmptyLinesAroundBlockBody:
-  Enabled: false
-
-AllCops:
-  Exclude:
-    - 'cookbooks/**/*'

--- a/scripts/update-vm.sh
+++ b/scripts/update-vm.sh
@@ -95,12 +95,11 @@ verify_vm() {
   cd $REPO_ROOT/cookbooks/vm
 
   # run lint checks
-  step "run codestyle checks"
-  rubocop . --format progress --format offenses --display-cop-names --color
+  step "run foodcritic linting checks"
   foodcritic -f any .
 
   # run integration tests
-  step "run integration tests"
+  step "run serverspec integration tests"
   rspec --require rspec_junit_formatter --format doc --color --tty --format RspecJunitFormatter --out test/junit-report.xml --format html --out test/test-report.html
 }
 


### PR DESCRIPTION
We really never used it honestly (almost everything in cookbooks/** was ignored), so let's get rid of it