### PR TITLE
Fix berks cache when using vagrant-cachier

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,7 +34,7 @@ Vagrant::configure("2") do |config|
   if Vagrant.has_plugin?("vagrant-cachier")
     config.cache.enable :generic, {
       "chef_file_cache" => { cache_dir: "/root/.chef/local-mode-cache/cache" },
-      "berks_cookbooks_cache" => { cache_dir: "/home/vagrant/.berkshelf/cookbooks" }
+      "berks_cache" => { cache_dir: "/home/vagrant/.berkshelf" }
     }
   end
 end


### PR DESCRIPTION
We need to cache the whole `~/.berkshelf` directory, otherwise we run into permission issues when using git based cookbook dependencies, e.g.:

```
==> default: >>>>>> install cookbook dependencies
==> default: -------------------------------------
==> default: Resolving cookbook dependencies...
==> default: Fetching 'eclipse' from https://github.com/geocent-cookbooks/eclipse (at master)
==> default: Git error: command `git clone https://github.com/geocent-cookbooks/eclipse "/home/vagrant/.berkshelf/.cache/git/df739884e0e7f6f62ef34d6f4ee141c062e3956a" --bare --no-hardlinks` failed. If this error persists, try removing the cache directory at '/home/vagrant/.berkshelf/.cache/git/df739884e0e7f6f62ef34d6f4ee141c062e3956a'.Output from the command:
==> default: 
==> default: fatal: could not create leading directories of '/home/vagrant/.berkshelf/.cache/git/df739884e0e7f6f62ef34d6f4ee141c062e3956a'
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
```
