### PR TITLE
Fix handling of commandline flags in update-vm.sh

### DIFF
--- a/scripts/update-vm.sh
+++ b/scripts/update-vm.sh
@@ -4,16 +4,17 @@ set -e -o pipefail
 CHEFDK_VERSION="1.3.32"
 DOWNLOAD_DIR="/tmp/vagrant-cache/wget"
 REPO_ROOT="/home/vagrant/vm-setup"
+FLAGS=$1
 
 main() {
   setup_chefdk
-  if [[ "$1" == "--verify-only" ]]; then
+  if [[ "$FLAGS" == "--verify-only" ]]; then
     verify_vm
   else
     copy_repo_and_symlink_self
-    [[ "$1" == "--pull" ]] && update_repo
+    [[ "$FLAGS" == "--pull" ]] && update_repo
     update_vm
-    [[ "$1" == "--provision-only" ]] || verify_vm
+    [[ "$FLAGS" == "--provision-only" ]] || verify_vm
   fi
 }
 


### PR DESCRIPTION
The handling of the commandline flags was broken in 9f56e097b96592790e9dc11d296f1e12c0c21938

This PR fixes it