### PR TITLE
Update ChefDK v1.3.40 and use the "stable" channel

### DIFF
--- a/cookbooks/vm/metadata.rb
+++ b/cookbooks/vm/metadata.rb
@@ -8,6 +8,8 @@ version '0.1.0'
 issues_url 'https://github.com/Zuehlke/linux-developer-vm/issues'
 source_url 'https://github.com/Zuehlke/linux-developer-vm'
 
+chef_version '~> 12'
+
 supports 'ubuntu'
 
 depends 'apt', '6.0.1'

--- a/cookbooks/vm/spec/integration/scripts/update_vm_spec.rb
+++ b/cookbooks/vm/spec/integration/scripts/update_vm_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 
 describe 'update-vm.sh' do
 
-  it 'installs chefdk 1.3.32' do
-    expect(file('/opt/chefdk/version-manifest.txt')).to contain 'chefdk 1.3.32'
+  it 'installs chefdk 1.3.40' do
+    expect(file('/opt/chefdk/version-manifest.txt')).to contain 'chefdk 1.3.40'
   end
 
   it 'symlinks the update-vm script to /usr/local/bin/' do

--- a/scripts/update-vm.sh
+++ b/scripts/update-vm.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e -o pipefail
 
-CHEFDK_VERSION="1.3.32"
+CHEFDK_VERSION="1.3.40"
 DOWNLOAD_DIR="/tmp/vagrant-cache/wget"
 REPO_ROOT="/home/vagrant/vm-setup"
 FLAGS=$1
@@ -26,7 +26,7 @@ setup_chefdk() {
     step "Downloading and installing ChefDK $CHEFDK_VERSION"
     mkdir -p $DOWNLOAD_DIR
     local CHEFDK_DEB=chefdk_$CHEFDK_VERSION-1_amd64.deb
-    local CHEFDK_URL=https://packages.chef.io/files/current/chefdk/$CHEFDK_VERSION/ubuntu/16.04/$CHEFDK_DEB
+    local CHEFDK_URL=https://packages.chef.io/files/stable/chefdk/$CHEFDK_VERSION/ubuntu/16.04/$CHEFDK_DEB
     [[ -f $DOWNLOAD_DIR/$CHEFDK_DEB ]] || wget --no-verbose -O $DOWNLOAD_DIR/$CHEFDK_DEB $CHEFDK_URL
     sudo dpkg -i $DOWNLOAD_DIR/$CHEFDK_DEB
   fi


### PR DESCRIPTION
It seems that the "current" channel only hosts the latest available / most current version of the chefdk. So it happened that 1.3.32 is no longer available anymore, see failing build here:
https://circleci.com/gh/Zuehlke/linux-developer-vm/104

With this PR we switch to the "stable" channel and update to the latest ChefDK 1.3.40 therein